### PR TITLE
Remove explicit installation of brave-keyring

### DIFF
--- a/we-want-brave.sh
+++ b/we-want-brave.sh
@@ -127,7 +127,7 @@ fi
 
 #continue
 echo "Installing Brave browser"
-apt install brave-browser brave-keyring
+apt install brave-browser
 
 #verify if command ran successfully, otherwise exit
 if [[ $? -ne 0 ]] ; then


### PR DESCRIPTION
As of brave/brave-core#2338, the `brave-browser` package depends
on `brave-keyring` and will pull it in automatically.