### PR TITLE
Add -y (yes) flag to apt install commands

### DIFF
--- a/we-want-brave.sh
+++ b/we-want-brave.sh
@@ -85,7 +85,7 @@ if [[ $? -eq 127 ]] ; then
 	        echo "The curl package is not installed on your system, but is required to complete the installation. Would you like this script to install curl now? [y/n] (choosing n will exit the script)."
                 read curl_input
                 if [[ $curl_input = 'y' ]] ; then
-                        apt install curl
+                        apt install curl -y
                 elif [[ $curl_input = 'n' ]] ; then
                         echo "Installation aborted. Goodbye!"
                         exit
@@ -127,7 +127,7 @@ fi
 
 #continue
 echo "Installing Brave browser"
-apt install brave-browser
+apt install brave-browser -y
 
 #verify if command ran successfully, otherwise exit
 if [[ $? -ne 0 ]] ; then


### PR DESCRIPTION
So the user doesn't have to answer the y/n prompts after choosing to install brave, e.g.:
The following NEW packages will be installed:
  brave-browser brave-keyring libvulkan1
0 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.
Need to get 96,8 MB of archives.
After this operation, 300 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
